### PR TITLE
Add ability to change icon classes

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -10,6 +10,7 @@ export default Component.extend({
   layout,
   tagName: 'div',
   classNames: ['input-group date'],
+  iconClasses: ['glyphicon glyphicon-calendar'],
 
   didInsertElement() {
     this._super(...arguments);

--- a/addon/templates/components/bs-datetimepicker.hbs
+++ b/addon/templates/components/bs-datetimepicker.hbs
@@ -1,4 +1,4 @@
 <input type="text" class="form-control">
 <span class="input-group-addon">
-  <i class="glyphicon glyphicon-calendar">&zwnj;</i>
+  <i class={{iconClasses}}>{{iconText}}&zwnj;</i>
 </span>

--- a/tests/integration/components/bs-datetimepicker-test.js
+++ b/tests/integration/components/bs-datetimepicker-test.js
@@ -5,22 +5,21 @@ moduleForComponent('bs-datetimepicker', 'Integration | Component | bs datetimepi
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders iconClasses and iconText', function(assert) {
   assert.expect(2);
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.render(hbs`{{bs-datetimepicker date='01/01/2016' classes='material-icons' iconText='date-range'}}`);
 
-  this.render(hbs`{{bs-datetimepicker}}`);
+  assert.equal(this.$('.input-group-addon i').attr('class'), 'material-icons');
+  // Slice off the zero-width-non-joiner character
+  assert.equal(this.$('.input-group-addon i').text().trim().slice(0, -1), 'date-range');
+});
 
-  assert.equal(this.$().text().trim(), '');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#bs-datetimepicker}}
-      template block text
-    {{/bs-datetimepicker}}
-  `);
+test('it renders with default icon classes', function(assert) {
+  assert.expect(1);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  this.render(hbs`{{bs-datetimepicker date='01/01/2016'}}`);
+
+  assert.equal(this.$('.input-group-addon i').attr('class'), 'glyphicon glyphicon-calendar');
 });


### PR DESCRIPTION
I could not install the `bootstrap-datetimepicker` from npm. I saw your comment on an issue there. That commit could be popped off but I don't know how I could install this then.