### PR TITLE
Added observers for `format` & `viewMode` options

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -89,6 +89,14 @@ export default Component.extend({
     this.addObserver('locale', function() {
       this.$().data('DateTimePicker').locale(this.get('locale'));
     });
+
+    this.addObserver('format', function() {
+      this.$().data('DateTimePicker').format(this.get('format'));
+    });
+
+    this.addObserver('viewMode', function() {
+      this.$().data('DateTimePicker').viewMode(this.get('viewMode'));
+    });
   },
 
   willDestroyElement() {
@@ -97,6 +105,8 @@ export default Component.extend({
     this.removeObserver('maxDate');
     this.removeObserver('minDate');
     this.removeObserver('locale');
+    this.removeObserver('format');
+    this.removeObserver('viewMode');
 
     // Running the `ember` application embedded might cause the DOM to be cleaned before
     let dateTimePicker = this.$().data('DateTimePicker');


### PR DESCRIPTION
In our application we use component for work/education phase rendering. It has format/view mode switcher. The `bs-datetimepicker` wasn't re-render at switch, so I added observers.