### PR TITLE
Observer set `date` with default `null` value

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -74,7 +74,7 @@ export default Component.extend({
     });
 
     this.addObserver('date', function() {
-      this.$().data('DateTimePicker').date(this.get('date'));
+      this.$().data('DateTimePicker').date(this.getWithDefault('date', null));
     });
 
     this.addObserver('maxDate', function() {


### PR DESCRIPTION
I noticed that observer updates `date` value with `undefined` and this triggers #29 issue in my project.
*Solution*: force observer to set `null` as default when updates `date` property.