### PR TITLE
remove input when displaying inline

### DIFF
--- a/addon/templates/components/bs-datetimepicker.hbs
+++ b/addon/templates/components/bs-datetimepicker.hbs
@@ -1,6 +1,8 @@
-<input type="text" class="form-control {{if isMobile 'bs-disable'}}" placeholder={{placeholder}} readonly={{isMobile}} onfocus={{action 'focus'}}>
-{{#if showIcon}}
-  <span class="input-group-addon">
-    <i class={{iconClasses}}></i>
-  </span>
-{{/if}}
+{{#unless inline}}
+  <input type="text" class="form-control {{if isMobile 'bs-disable'}}" placeholder={{placeholder}} readonly={{isMobile}} onfocus={{action 'focus'}}>
+  {{#if showIcon}}
+    <span class="input-group-addon">
+      <i class={{iconClasses}}></i>
+    </span>
+  {{/if}}
+{{/unless}}


### PR DESCRIPTION
resolve an issue where enabling "inline" would display
both the inline input and the text field with the icon

**from**
![image](https://user-images.githubusercontent.com/9534435/29321950-ff32ee2a-81a9-11e7-93b2-108ef9446778.png)

**to** 
![image](https://user-images.githubusercontent.com/9534435/29321993-146b9396-81aa-11e7-9bdf-30748bc9fd05.png)
