### PR TITLE
fix default "inline" parameter value

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -54,7 +54,7 @@ export default Component.extend({
       format: this.getWithDefault('format', defaults.format),
       icons,
       ignoreReadonly: this.isMobile || defaults.ignoreReadonly,
-      inline: this.getWithDefault('inline', defaults.locale),
+      inline: this.getWithDefault('inline', defaults.inline),
       locale: this.getWithDefault('locale', defaults.locale),
       maxDate: this.getWithDefault('maxDate', defaults.maxDate),
       minDate: this.getWithDefault('minDate', defaults.minDate),


### PR DESCRIPTION
this is embarassing, but instantiating the `bs-datetimepicker` without specifying an "inline" option would result in a crash with the following error : 

`inline() is expecting a boolean`

we should be done now for this `inline` option