### PR TITLE
Added dynamic data attribute bindings support

### DIFF
--- a/addon/-private/LICENCE.md
+++ b/addon/-private/LICENCE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 DockYard, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/addon/-private/LICENCE.md
+++ b/addon/-private/LICENCE.md
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright (c) 2016 DockYard, Inc
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/addon/-private/dynamic-attribute-bindings.js
+++ b/addon/-private/dynamic-attribute-bindings.js
@@ -1,0 +1,19 @@
+import Mixin from '@ember/object/mixin';
+import { set } from '@ember/object';
+
+export default Mixin.create({
+  NON_ATTRIBUTE_BOUND_PROPS: ['class', 'classNames'],
+  concatenatedProperties: ['NON_ATTRIBUTE_BOUND_PROPS'],
+  init() {
+    this._super(...arguments);
+
+    let newAttributeBindings = [];
+    for (let key in this.attrs) {
+      if (this.NON_ATTRIBUTE_BOUND_PROPS.indexOf(key) === -1 && this.attributeBindings.indexOf(key) === -1) {
+        newAttributeBindings.push(key);
+      }
+    }
+
+    set(this, 'attributeBindings', this.attributeBindings.concat(newAttributeBindings));
+  }
+});

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -2,12 +2,14 @@ import $ from 'jquery';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/bs-datetimepicker';
+import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 const {
   defaults
 } = $.fn.datetimepicker;
 
-export default Component.extend({
+export default Component.extend(DynamicAttributeBindings, {
+  attributeBindings: null,
   layout,
   tagName: 'div',
   classNames: ['input-group date'],


### PR DESCRIPTION
This small addon included in some of DockYard projects is really useful so you can add any data- attributes to the component, useful for example if you're using bootstrap popovers or other data binding.

Added a license from DockYard as it seems the right thing to do in this case, they don't seem eager to publish this as a separate package, though.