### PR TITLE
Added widgetParent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Accepts: `string`
 {{bs-datetimepicker date=myDate timeZone='Europe/Berlin'}}
 ```
 
-Set timezone
+Set timezone.
 
 
 #### useCurrent
@@ -358,7 +358,7 @@ Accepts: 'years', 'months', 'days'
 ```
 
 The default view to display when the picker is shown.
-*Note:* To limit the picker to selecting, for instance the year and month, use format: `MM/YYYY`
+*Note:* To limit the picker to selecting, for instance the year and month, use format: `MM/YYYY`.
 
 #### widgetParent
 
@@ -370,7 +370,7 @@ Accepts: string or jQuery object
 {{bs-datetimepicker date=myDate widgetParent='#an-element-id'}}
 ```
 
-On picker show, places the widget at the identifier (string) or jQuery object if the element has css position: 'relative'
+On picker show, places the widget at the identifier (string) or jQuery object if the element has css position: 'relative'.
 
 #### widgetPositioning
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The default view to display when the picker is shown.
 
 #### widgetParent
 
-Default: null
+Default: `null`
 
 Accepts: string or jQuery object
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,17 @@ Accepts: 'years', 'months', 'days'
 The default view to display when the picker is shown.
 *Note:* To limit the picker to selecting, for instance the year and month, use format: `MM/YYYY`
 
+#### widgetParent
 
+Default: null
+
+Accepts: string or jQuery object
+
+```handlebars
+{{bs-datetimepicker date=myDate widgetParent='#an-element-id'}}
+```
+
+On picker show, places the widget at the identifier (string) or jQuery object if the element has css position: 'relative'
 
 #### widgetPositioning
 

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -65,8 +65,8 @@ export default Component.extend(DynamicAttributeBindings, {
       useCurrent: this.getWithDefault('useCurrent', false),
       viewDate: this.getWithDefault('viewDate', defaults.viewDate),
       viewMode: this.getWithDefault('viewMode', defaults.viewMode),
-      widgetPositioning: this.getWithDefault('widgetPositioning', defaults.widgetPositioning),
-      widgetParent: this.getWithDefault('widgetParent', defaults.widgetParent)
+      widgetParent: this.getWithDefault('widgetParent', defaults.widgetParent),
+      widgetPositioning: this.getWithDefault('widgetPositioning', defaults.widgetPositioning)
     }).on('dp.change', e => {
       // Convert moment to js date or default to null
       let newDate = e.date && e.date.toDate() || null;

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -65,7 +65,8 @@ export default Component.extend(DynamicAttributeBindings, {
       useCurrent: this.getWithDefault('useCurrent', false),
       viewDate: this.getWithDefault('viewDate', defaults.viewDate),
       viewMode: this.getWithDefault('viewMode', defaults.viewMode),
-      widgetPositioning: this.getWithDefault('widgetPositioning', defaults.widgetPositioning)
+      widgetPositioning: this.getWithDefault('widgetPositioning', defaults.widgetPositioning),
+      widgetParent: this.getWithDefault('widgetParent', defaults.widgetParent)
     }).on('dp.change', e => {
       // Convert moment to js date or default to null
       let newDate = e.date && e.date.toDate() || null;


### PR DESCRIPTION
Added widgetParent option (to set the modal yourself, if the `{{bootstrap-datepicker}}` is inside a element with an `overflow` property)