### PR TITLE
replace sendAction call with closure action

### DIFF
--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -73,7 +73,9 @@ export default Component.extend(DynamicAttributeBindings, {
       let newDate = e.date && e.date.toDate() || null;
 
       this.set('date', newDate);
-      this.sendAction('change', newDate);
+      if (this.change) {
+        this.change(newDate);
+      }
     });
 
     this.addObserver('date', function() {


### PR DESCRIPTION
This clears the deprecation warnings related to https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action that start appearing in ember 3.4.