### PR TITLE
Handle hide/show events

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ Returns: `date`, `null`
 
 Fired when the date is changed.
 
+```handlebars
+{{bs-datetimepicker change=(action onChange)}}
+```
+
+#### hide
+
+Returns: `null`
+
+Fired when the date picker is hidden.
+
+```handlebars
+{{bs-datetimepicker hide=(action onHide)}}
+```
+
+#### show
+
+Returns: `null`
+
+Fired when the date picker is shown.
+
+```handlebars
+{{bs-datetimepicker show=(action onShow)}}
+```
+
 
 
 ### Available options

--- a/addon/components/bs-datetimepicker.js
+++ b/addon/components/bs-datetimepicker.js
@@ -76,6 +76,14 @@ export default Component.extend(DynamicAttributeBindings, {
       if (this.change) {
         this.change(newDate);
       }
+    }).on('dp.show', e => {
+      if (this.show) {
+        this.show();
+      }
+    }).on('dp.hide', e => {
+      if (this.hide) {
+        this.hide();
+      }
     });
 
     this.addObserver('date', this, 'updateDate');


### PR DESCRIPTION
BS date time picker show/hide events are not expose in component level. Added event handlers to call show(), hide() attributes if user config into component.